### PR TITLE
Maximum Operating Depth Divide by Zero

### DIFF
--- a/Sources/DiveKit/Implementation/GasCalculator.swift
+++ b/Sources/DiveKit/Implementation/GasCalculator.swift
@@ -47,12 +47,20 @@ extension GasCalculator: GasCalculating {
 
     public func maximumOperatingDepth(
         for fractionOxygen: FractionalPressure,
-        in blend: Blend<Blended>) throws ->  Calculation<DecimalResult<Depth>> {
-            try fractionOxygen.validate(using: .nonNegative, orThrow: { .negative($0, .from(self)) })
-                .map { try $0.value / blend.pressure(of: .oxygen) }
+        in blend: Blend<Blended>) throws -> Calculation<DecimalResult<Depth>> {
+            try blend.pressure(of: .oxygen)
+                .validate(using: .greater(than: 0)) {
+                    .range(.lowerBound($0, 0), .from(self))
+                }
+                .with { _ in
+                   try fractionOxygen.validate(using: .greater(than: 0), orThrow: {
+                       .range(.lowerBound($0.value, 0), .from(self))
+                   })
+                }
+                .map { $0.second.value / $0.first }
                 .map { $0 - 1 }
                 .map { $0 * configuration.water.pressure(configuration.units).increase.value }
-                .map {.decimal($0, unit: \.depth, from: configuration) }
+                .map { .decimal($0, unit: \.depth, from: configuration) }
         }
 
     public func partialPressure<Gas: GasRepresentable>(

--- a/Sources/DiveKit/Internal/Calculation+Tuple.swift
+++ b/Sources/DiveKit/Internal/Calculation+Tuple.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 internal extension Calculation {
-    func with(_ other: () throws -> Calculation) rethrows -> Tuple<Self> {
+    func with(_ other: () throws -> Calculation) rethrows -> Tuple<Self, Self> {
         .init(first: self, second: try other())
     }
 }

--- a/Sources/DiveKit/Internal/Double+Tuple.swift
+++ b/Sources/DiveKit/Internal/Double+Tuple.swift
@@ -1,7 +1,13 @@
 import Foundation
 
 internal extension Double {
-    func with(_ transform: () throws -> Self) rethrows -> Tuple<Self> {
+    func with(_ transform: () throws -> Self) rethrows -> Tuple<Self, Self> {
         try .init(first: self, second: transform())
+    }
+}
+
+internal extension Double {
+    func with<Other>(_ transform: (Self) throws -> Other) rethrows -> Tuple<Self, Other> {
+        try .init(first: self, second: transform(self))
     }
 }

--- a/Sources/DiveKit/Internal/Localization/LocalizedKey.swift
+++ b/Sources/DiveKit/Internal/Localization/LocalizedKey.swift
@@ -10,8 +10,8 @@ internal extension LocalizedKey {
 
 internal extension LocalizedKey.Error {
     enum Range {
-        static let lowerBound: LocalizedStringKey = "dive.kit.range.lower.bound"
-        static let upperBound: LocalizedStringKey = "dive.kit.range.upper.bound"
+        static let lowerBound: LocalizedStringKey = "dive.kit.error.range.lower.bound"
+        static let upperBound: LocalizedStringKey = "dive.kit.error.range.upper.bound"
     }
 }
 

--- a/Sources/DiveKit/Internal/Tuple.swift
+++ b/Sources/DiveKit/Internal/Tuple.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-internal struct Tuple<Value> {
+internal struct Tuple<Value, Other> {
     internal let first: Value
-    internal let second: Value
+    internal let second: Other
 
-    internal init(first: Value, second: Value) {
+    internal init(first: Value, second: Other) {
         self.first = first
         self.second = second
     }

--- a/Sources/DiveKit/Internal/Validator/Validator+DecimalRepresentable.swift
+++ b/Sources/DiveKit/Internal/Validator/Validator+DecimalRepresentable.swift
@@ -4,4 +4,8 @@ internal extension Validator where Value: DecimalRepresentable {
     static var nonNegative: Self {
         .init { $0 >= .zero }
     }
+
+    static func greater(than bound: Value) -> Self {
+        .init { $0 > bound }
+    }
 }

--- a/Sources/DiveKit/Resources/Localizable.xcstrings
+++ b/Sources/DiveKit/Resources/Localizable.xcstrings
@@ -81,6 +81,12 @@
         }
       }
     },
+    "dive.kit.error.range.lower.bound" : {
+
+    },
+    "dive.kit.error.range.upper.bound" : {
+
+    },
     "dive.kit.error.tank.size.rated.pressure" : {
       "localizations" : {
         "en" : {
@@ -101,9 +107,6 @@
         }
       }
     },
-    "dive.kit.range.lower.bound" : {
-
-    },
     "dive.kit.range.out.of.range" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -114,9 +117,6 @@
           }
         }
       }
-    },
-    "dive.kit.range.upper.bound" : {
-
     },
     "dive.kit.unit.depth.imperial.description.full" : {
       "localizations" : {

--- a/Tests/DiveKitTests/TestCases/CalculatorTests/GasCalculator/GasCalculatorImperialSaltwaterTestCase+MaximumOperatingDepth.swift
+++ b/Tests/DiveKitTests/TestCases/CalculatorTests/GasCalculator/GasCalculatorImperialSaltwaterTestCase+MaximumOperatingDepth.swift
@@ -5,7 +5,38 @@ extension GasCalculatorImperialSaltwaterTestCase {
 
     // MARK: maximumOperatingDepth(for:in:)
 
-    func testMaximumOperatingDepthValidInput() throws {
+    func testMaximumOperatingDepthForEAN28AtOnePointFour() throws {
+        // Given
+        let fractionOxygen: FractionalPressure = 1.4
+        let blend = try Blend<Blended>.enrichedAir(0.28)
+
+        // When
+        try XCTAssertCalculation(
+            sut.maximumOperatingDepth(for: fractionOxygen, in: blend)) { result, configuration in
+                // Then
+                XCTAssertEqual(result.value, 131.99999719006675, accuracy: 0.0001)
+                XCTAssertEqual(result.unit, .feet)
+                XCTAssertEqual(configuration, sut.configuration)
+            }
+    }
+
+    func testMaximumOperatingDepthForEAN30AtOnePointFour() throws {
+        // Given
+        let fractionOxygen: FractionalPressure = 1.4
+        let blend = try Blend<Blended>.enrichedAir(0.30)
+
+        // When
+        try XCTAssertCalculation(
+            sut.maximumOperatingDepth(for: fractionOxygen, in: blend)) { result, configuration in
+                // Then
+                XCTAssertEqual(result.value, 120.99999737739564, accuracy: 0.0001)
+                XCTAssertEqual(result.unit, .feet)
+                XCTAssertEqual(configuration, sut.configuration)
+            }
+    }
+
+    func testMaximumOperatingDepthForEAN32AtOnePointFour() throws {
+        // Given
         let fractionOxygen: FractionalPressure = 1.4
         let blend = try Blend<Blended>.enrichedAir(0.32)
 
@@ -13,22 +44,227 @@ extension GasCalculatorImperialSaltwaterTestCase {
         try XCTAssertCalculation(
             sut.maximumOperatingDepth(for: fractionOxygen, in: blend)) { result, configuration in
                 // Then
-                XCTAssertEqual(result.value, 111.3749975413084)
+                XCTAssertEqual(result.value, 111.3749975413084, accuracy: 0.0001)
                 XCTAssertEqual(result.unit, .feet)
                 XCTAssertEqual(configuration, sut.configuration)
             }
     }
 
-    func testMaximumOperatingDepthInvalidInput() throws {
+    func testMaximumOperatingDepthForEAN34AtOnePointFour() throws {
+        // Given
+        let fractionOxygen: FractionalPressure = 1.4
+        let blend = try Blend<Blended>.enrichedAir(0.34)
+
+        // When
+        try XCTAssertCalculation(
+            sut.maximumOperatingDepth(for: fractionOxygen, in: blend)) { result, configuration in
+                // Then
+                XCTAssertEqual(result.value, 102.88235062711377, accuracy: 0.0001)
+                XCTAssertEqual(result.unit, .feet)
+                XCTAssertEqual(configuration, sut.configuration)
+            }
+    }
+
+    func testMaximumOperatingDepthForEAN36AtOnePointFour() throws {
+        // Given
+        let fractionOxygen: FractionalPressure = 1.4
+        let blend = try Blend<Blended>.enrichedAir(0.36)
+
+        // When
+        try XCTAssertCalculation(
+            sut.maximumOperatingDepth(for: fractionOxygen, in: blend)) { result, configuration in
+                // Then
+                XCTAssertEqual(result.value, 95.3333311478297, accuracy: 0.0001)
+                XCTAssertEqual(result.unit, .feet)
+                XCTAssertEqual(configuration, sut.configuration)
+            }
+    }
+
+    func testMaximumOperatingDepthForEAN40AtOnePointFour() throws {
+        // Given
+        let fractionOxygen: FractionalPressure = 1.4
+        let blend = try Blend<Blended>.enrichedAir(0.40)
+
+        // When
+        try XCTAssertCalculation(
+            sut.maximumOperatingDepth(for: fractionOxygen, in: blend)) { result, configuration in
+                // Then
+                XCTAssertEqual(result.value, 82.49999803304672, accuracy: 0.0001)
+                XCTAssertEqual(result.unit, .feet)
+                XCTAssertEqual(configuration, sut.configuration)
+            }
+    }
+
+    func testMaximumOperatingDepthForEAN28AtOnePointSix() throws {
+        // Given
+        let fractionOxygen: FractionalPressure = 1.6
+        let blend = try Blend<Blended>.enrichedAir(0.28)
+
+        // When
+        try XCTAssertCalculation(
+            sut.maximumOperatingDepth(for: fractionOxygen, in: blend)) { result, configuration in
+                // Then
+                XCTAssertEqual(result.value, 155.5714313813618, accuracy: 0.0001)
+                XCTAssertEqual(result.unit, .feet)
+                XCTAssertEqual(configuration, sut.configuration)
+            }
+    }
+
+    func testMaximumOperatingDepthForEAN30AtOnePointSix() throws {
+        // Given
+        let fractionOxygen: FractionalPressure = 1.6
+        let blend = try Blend<Blended>.enrichedAir(0.30)
+
+        // When
+        try XCTAssertCalculation(
+            sut.maximumOperatingDepth(for: fractionOxygen, in: blend)) { result, configuration in
+                // Then
+                XCTAssertEqual(result.value, 143.00000262260437, accuracy: 0.0001)
+                XCTAssertEqual(result.unit, .feet)
+                XCTAssertEqual(configuration, sut.configuration)
+            }
+    }
+
+    func testMaximumOperatingDepthForEAN32AtOnePointSix() throws {
+        // Given
+        let fractionOxygen: FractionalPressure = 1.6
+        let blend = try Blend<Blended>.enrichedAir(0.32)
+
+        // When
+        try XCTAssertCalculation(
+            sut.maximumOperatingDepth(for: fractionOxygen, in: blend)) { result, configuration in
+                // Then
+                XCTAssertEqual(result.value, 132.0000024586916, accuracy: 0.0001)
+                XCTAssertEqual(result.unit, .feet)
+                XCTAssertEqual(configuration, sut.configuration)
+            }
+    }
+
+    func testMaximumOperatingDepthForEAN34AtOnePointSix() throws {
+        // Given
+        let fractionOxygen: FractionalPressure = 1.6
+        let blend = try Blend<Blended>.enrichedAir(0.34)
+
+        // When
+        try XCTAssertCalculation(
+            sut.maximumOperatingDepth(for: fractionOxygen, in: blend)) { result, configuration in
+                // Then
+                XCTAssertEqual(result.value, 122.29411996112148, accuracy: 0.0001)
+                XCTAssertEqual(result.unit, .feet)
+                XCTAssertEqual(configuration, sut.configuration)
+            }
+    }
+
+    func testMaximumOperatingDepthForEAN36AtOnePointSix() throws {
+        // Given
+        let fractionOxygen: FractionalPressure = 1.6
+        let blend = try Blend<Blended>.enrichedAir(0.36)
+
+        // When
+        try XCTAssertCalculation(
+            sut.maximumOperatingDepth(for: fractionOxygen, in: blend)) { result, configuration in
+                // Then
+                XCTAssertEqual(result.value, 113.6666688521703, accuracy: 0.0001)
+                XCTAssertEqual(result.unit, .feet)
+                XCTAssertEqual(configuration, sut.configuration)
+            }
+    }
+
+    func testMaximumOperatingDepthForEAN40AtOnePointSix() throws {
+        // Given
+        let fractionOxygen: FractionalPressure = 1.6
+        let blend = try Blend<Blended>.enrichedAir(0.40)
+
+        // When
+        try XCTAssertCalculation(
+            sut.maximumOperatingDepth(for: fractionOxygen, in: blend)) { result, configuration in
+                // Then
+                XCTAssertEqual(result.value, 99.00000196695328, accuracy: 0.0001)
+                XCTAssertEqual(result.unit, .feet)
+                XCTAssertEqual(configuration, sut.configuration)
+            }
+    }
+
+    func testMaximumOperatingDepthForAirAtOnePointFour() throws {
+        // Given
+        let fractionOxygen: FractionalPressure = 1.4
+        let blend = Blend<Blended>.air
+
+        // When
+        try XCTAssertCalculation(
+            sut.maximumOperatingDepth(for: fractionOxygen, in: blend)) { result, configuration in
+                // Then
+                XCTAssertEqual(result.value, 188.0526278144435, accuracy: 0.0001)
+                XCTAssertEqual(result.unit, .feet)
+                XCTAssertEqual(configuration, sut.configuration)
+            }
+    }
+
+    func testMaximumOperatingDepthForAirAtOnePointSix() throws {
+        // Given
+        let fractionOxygen: FractionalPressure = 1.6
+        let blend = Blend<Blended>.air
+
+        // When
+        try XCTAssertCalculation(
+            sut.maximumOperatingDepth(for: fractionOxygen, in: blend)) { result, configuration in
+                // Then
+                XCTAssertEqual(result.value, 219.6315827118723, accuracy: 0.0001)
+                XCTAssertEqual(result.unit, .feet)
+                XCTAssertEqual(configuration, sut.configuration)
+            }
+    }
+
+    func testMaximumOperatingDepthRejectsNegativeFractionOxygen() throws {
         let fractionOxygen: FractionalPressure = -1.4
         let blend = try Blend<Blended>.enrichedAir(0.32)
-        expectedError = .negative(fractionOxygen, "GasCalculator.maximumOperatingDepth(for:in:)")
+        expectedError = .range(
+            .lowerBound(fractionOxygen.value, 0),
+            "GasCalculator.maximumOperatingDepth(for:in:)")
 
         // When
         try XCTAssertThrowsError(
             when: sut.maximumOperatingDepth(for: fractionOxygen, in: blend),
             then: expectedError) {
-                XCTAssertEqual($0.localizationKey, "dive.kit.error.negative.fractional.pressure")
+                XCTAssertEqual($0.localizationKey, "dive.kit.error.range.lower.bound")
+            }
+    }
+
+    func testMaximumOperatingDepthRejectsBlendWithZeroOxygen() throws {
+        // Given
+        let fractionalPressure = FractionalPressure(1.4)
+
+        let blend = try Blend<Blended> { () throws(DiveKit.Error) in
+            try PartialPressure(of: .oxygen, fractionalPressure: 0.0)
+            try PartialPressure(of: .nitrogen, fractionalPressure: 1.0)
+        }
+
+        expectedError = .range(
+            .lowerBound(0, 0),
+            "GasCalculator.maximumOperatingDepth(for:in:)")
+
+        // When / Then
+        try XCTAssertThrowsError(
+            when: sut.maximumOperatingDepth(for: fractionalPressure, in: blend),
+            then: expectedError) {
+                XCTAssertEqual($0.localizationKey, "dive.kit.error.range.lower.bound")
+            }
+    }
+
+    func testMaximumOperatingDepthRejectsZeroFractionOxygen() throws {
+        // Given
+        let fractionOxygen: FractionalPressure = 0
+        let blend = try Blend<Blended>.enrichedAir(0.32)
+
+        expectedError = .range(
+            .lowerBound(0, 0),
+            "GasCalculator.maximumOperatingDepth(for:in:)")
+
+        // When / Then
+        try XCTAssertThrowsError(
+            when: sut.maximumOperatingDepth(for: fractionOxygen, in: blend),
+            then: expectedError) {
+                XCTAssertEqual($0.localizationKey, "dive.kit.error.range.lower.bound")
             }
     }
 }

--- a/Tests/DiveKitTests/TestCases/PartialPressureTestCase.swift
+++ b/Tests/DiveKitTests/TestCases/PartialPressureTestCase.swift
@@ -27,7 +27,7 @@ final class PartialPressureTestCase: XCTestCase {
         try XCTAssertThrowsError(
             when: try PartialPressure(of: gas, fractionalPressure: fractionalPressure),
             then: expectedError) { error in
-                XCTAssertEqual(error.localizationKey, "dive.kit.range.lower.bound")
+                XCTAssertEqual(error.localizationKey, "dive.kit.error.range.lower.bound")
             }
     }
 
@@ -43,7 +43,7 @@ final class PartialPressureTestCase: XCTestCase {
         try XCTAssertThrowsError(
             when: try PartialPressure(of: gas, fractionalPressure: fractionalPressure),
             then: expectedError) { error in
-                XCTAssertEqual(error.localizationKey, "dive.kit.range.upper.bound")
+                XCTAssertEqual(error.localizationKey, "dive.kit.error.range.upper.bound")
             }
     }
 }


### PR DESCRIPTION
resolves an issue where it was possible for maximum operating depth where the fraction of oxygen in blend was 0.0